### PR TITLE
Fix: Add kotlin-reflect

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,6 +128,7 @@ dependencies {
     compileOnly(libs.spring.boot.starter.webflux)
 
     implementation(libs.spring.boot.starter)
+    implementation(libs.kotlin.reflect)
 
     testImplementation(libs.spring.boot.starter.test)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ releasePlugin = "3.0.2"
 springBoot = "2.6.5"    # lowest Spring Boot version that supports Gradle 8
 
 [libraries]
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }
 spring-boot-starter = { group = "org.springframework.boot", name = "spring-boot-starter" }
 spring-boot-starter-oauth2-client = { group = "org.springframework.boot", name = "spring-boot-starter-oauth2-client" }
 spring-boot-starter-oauth2-resource-server = { group = "org.springframework.boot", name = "spring-boot-starter-oauth2-resource-server" }


### PR DESCRIPTION
Spring requires `kotlin-reflect` to inspect Kotlin classes