### PR TITLE
Revert "Update spring boot to v2.7.12"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlinLib = "1.6.10"    # Kotlin version that is supported by spring-boot-depend
 kotlinPlugin = "1.8.22"
 ktlintPlugin = "11.4.0"
 releasePlugin = "3.0.2"
-springBoot = "2.7.12"    # lowest Spring Boot version with all required features
+springBoot = "2.2.3.RELEASE"    # lowest Spring Boot version with all required features
 
 [libraries]
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }


### PR DESCRIPTION
Renovate automatically updated Spring Boot to `2.7.12` (47615f53230a42cf8af5ff3b9c2f389e4c687a03). Revert back to version `2.2.3.RELEASE` (lowest version with all required features).