### PR TITLE
Migrate from gradle-build-action to setup-gradle action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,8 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Gradle build
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: build
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,14 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Publish package
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: >-
-            release
-            -Prelease.useAutomaticVersion=true
-            -Prelease.releaseVersion=${{ steps.get_version_from_branch.outputs.version }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Publish package with Gradle
+        run: >-
+          ./gradlew build
+          -Prelease.useAutomaticVersion=true
+          -Prelease.releaseVersion=${{ steps.get_version_from_branch.outputs.version }}
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
As of [v3](https://github.com/gradle/gradle-build-action/releases/tag/v3.0.0), [gradle/gradle-build-action](https://github.com/gradle/gradle-build-action) has been superceded by [gradle/actions/setup-gradle](https://github.com/gradle/actions/tree/main/setup-gradle)