### PR TITLE
Migrate from wrapper-validation-action to wrapper-validation action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As of [v3](https://github.com/gradle/wrapper-validation-action/releases/tag/v3.3.0), [gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action) has been superceded by [gradle/actions/wrapper-validation](https://github.com/gradle/actions/tree/main/wrapper-validation)