### PR TITLE
Feature: Customize OAuth2 Client Provider/Registration names

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ Spring Boot Starter for using Keycloak as the OAuth2 authorization server
 
 ## Configuration Properties
 
-| Configuration Property   | Mandatory/Optional | Description                                                                                                                                                    | Default |
-|--------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| keycloak.enabled         | Optional           | Set to `false` to disable Spring Security integration with Keycloak.                                                                                           | `true`  |
-| keycloak.auth-server-url | Mandatory          | The base URL of the Keycloak server. All other Keycloak pages and REST service endpoints are derived from this. It is usually of the form `https://host:port`. |         |
-| keycloak.realm           | Mandatory          | Name of the realm.                                                                                                                                             |         |
-| keycloak.client-id       | Mandatory          | The client-id of the application. Each application has a client-id that is used to identify the application.                                                   |         |
-| keycloak.client-secret   | Optional           | Only for clients with `Confidential` access type. Specify the credentials of the application.                                                                  |         |
-| keycloak.bearer-only     | Optional           | If enabled, will not attempt to authenticate users, but only verify bearer tokens.                                                                             | `true`  |
+| Configuration Property                                   | Mandatory/Optional | Description                                                                                                                                                    | Default  |
+|----------------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| keycloak.enabled                                         | Optional           | Set to `false` to disable Spring Security integration with Keycloak.                                                                                           | `true`   |
+| keycloak.auth-server-url                                 | Mandatory          | The base URL of the Keycloak server. All other Keycloak pages and REST service endpoints are derived from this. It is usually of the form `https://host:port`. |          |
+| keycloak.realm                                           | Mandatory          | Name of the realm.                                                                                                                                             |          |
+| keycloak.client-id                                       | Mandatory          | The client-id of the application. Each application has a client-id that is used to identify the application.                                                   |          |
+| keycloak.client-secret                                   | Optional           | Only for clients with `Confidential` access type. Specify the credentials of the application.                                                                  |          |
+| keycloak.bearer-only                                     | Optional           | If enabled, will not attempt to authenticate users, but only verify bearer tokens.                                                                             | `true`   |
+| keycloak.spring-security-oauth2-client-provider-name     | Optional           | The name of the Spring Security OAuth2 Client Provider to register.                                                                                            | keycloak |
+| keycloak.spring-security-oauth2-client-registration-name | Optional           | The name of the Spring Security OAuth2 Client Registration to register.                                                                                        | keycloak |
 
 ## Usage
 

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/KeycloakProperties.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/KeycloakProperties.kt
@@ -38,6 +38,16 @@ public data class KeycloakProperties(
      * If enabled, will not attempt to authenticate users, but only verify bearer tokens.
      */
     val bearerOnly: Boolean = false,
+
+    /**
+     * The name of the Spring Security OAuth2 Client Provider to register.
+     */
+    val springSecurityOauth2ClientProviderName: String = "keycloak",
+
+    /**
+     * The name of the Spring Security OAuth2 Client Registration to register.
+     */
+    val springSecurityOauth2ClientRegistrationName: String = "keycloak",
 ) {
     public companion object {
         public const val CONFIGURATION_PROPERTIES_PREFIX: String = "keycloak"


### PR DESCRIPTION
Allow Spring Security OAuth2 Client provider/registration names to be customized