### PR TITLE
Remove unused libs.versions.dependencyManagementPlugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-dependencyManagementPlugin = "1.1.0"
 dokka = "1.9.20"
 java = "8"
 kotlinLib = "1.6.10"    # Kotlin version that is supported by spring-boot-dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 dokka = "1.9.20"
 java = "8"
-kotlinLib = "1.6.10"    # Kotlin version that is supported by spring-boot-dependencies
+kotlinLib = "1.6.10"         # Kotlin version that is supported by spring-boot-dependencies
 kotlinPlugin = "1.9.24"
 ktlintPlugin = "11.6.1"
 releasePlugin = "3.0.2"
-springBoot = "2.2.3.RELEASE"    # lowest Spring Boot version with all required features
+springBoot = "2.2.3.RELEASE" # lowest Spring Boot version with all required features
 
 [libraries]
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }


### PR DESCRIPTION
`libs.versions.dependencyManagementPlugin` was previously used by the [Spring Boot Dependency Management Gradle plugin](https://docs.spring.io/dependency-management-plugin/docs/current/reference/html/), which was removed in #18