### PR TITLE
Add KeycloakClientConfiguredCondition

### DIFF
--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/KeycloakClientConfiguredCondition.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/KeycloakClientConfiguredCondition.kt
@@ -1,0 +1,36 @@
+package com.github.daniel.shuy.oauth2.keycloak.client
+
+import com.github.daniel.shuy.oauth2.keycloak.KeycloakProperties
+import org.springframework.boot.autoconfigure.condition.ConditionMessage
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.bind.DataObjectPropertyName
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.core.type.AnnotatedTypeMetadata
+
+internal object KeycloakClientConfiguredCondition : SpringBootCondition() {
+    private const val PROPERTY_SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION = "spring.security.oauth2.client.registration"
+
+    private val PROPERTY_SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_NAME =
+        "${KeycloakProperties.CONFIGURATION_PROPERTIES_PREFIX}.${DataObjectPropertyName.toDashedForm(KeycloakProperties::springSecurityOauth2ClientRegistrationName.name)}"
+
+    override fun getMatchOutcome(context: ConditionContext, metadata: AnnotatedTypeMetadata?): ConditionOutcome {
+        val message = ConditionMessage.forCondition("Keycloak Client Configured Condition")
+
+        val environment = context.environment
+        val registrationName = environment.getProperty(PROPERTY_SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_NAME)
+
+        val property = "$PROPERTY_SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION.$registrationName"
+
+        return Binder.get(environment)
+            .bind(property, OAuth2ClientProperties.Registration::class.java)
+            .map { registration ->
+                ConditionOutcome.match(
+                    message.found("registered Keycloak client").items(registration.clientId),
+                )
+            }
+            .orElseGet { ConditionOutcome.noMatch(message.didNotFind("$property property").atAll()) }
+    }
+}

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/reactive/KeycloakReactiveClientConfiguration.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/reactive/KeycloakReactiveClientConfiguration.kt
@@ -1,11 +1,11 @@
 package com.github.daniel.shuy.oauth2.keycloak.client.reactive
 
+import com.github.daniel.shuy.oauth2.keycloak.client.KeycloakClientConfiguredCondition
 import com.github.daniel.shuy.oauth2.keycloak.client.servlet.KeycloakOidcUserGrantedAuthoritiesConverter
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
-import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition
 import org.springframework.boot.autoconfigure.security.oauth2.client.reactive.ReactiveOAuth2ClientAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Conditional
@@ -24,7 +24,7 @@ import reactor.core.publisher.Flux
 internal class KeycloakReactiveClientConfiguration {
     @Bean
     @ConditionalOnMissingBean
-    @Conditional(ClientsConfiguredCondition::class) // somehow @ConditionalOnBean(ReactiveClientRegistrationRepository::class) doesn't work
+    @Conditional(KeycloakClientConfiguredCondition::class)
     fun keycloakReactiveOAuth2ClientConfigurer(
         clientRegistrationRepository: ReactiveClientRegistrationRepository,
     ): KeycloakReactiveOAuth2ClientConfigurer = DefaultKeycloakReactiveOAuth2ClientConfigurer(

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/servlet/KeycloakServletClientConfiguration.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/servlet/KeycloakServletClientConfiguration.kt
@@ -1,11 +1,11 @@
 package com.github.daniel.shuy.oauth2.keycloak.client.servlet
 
 import com.github.daniel.shuy.oauth2.keycloak.KeycloakJwtClaimsAuthoritiesConverter
+import com.github.daniel.shuy.oauth2.keycloak.client.KeycloakClientConfiguredCondition
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
-import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition
 import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Conditional
@@ -33,7 +33,7 @@ internal class KeycloakServletClientConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @Conditional(ClientsConfiguredCondition::class) // somehow @ConditionalOnBean(ClientRegistrationRepository::class) doesn't work
+    @Conditional(KeycloakClientConfiguredCondition::class)
     fun keycloakOAuth2ClientConfigurer(
         clientRegistrationRepository: ClientRegistrationRepository,
         keycloakOidcUserService: KeycloakOidcUserService,


### PR DESCRIPTION
`ClientsConfiguredCondition` checks if there are any OAuth2 client registrations, which causes `KeycloakOAuth2ClientConfigurer`/`KeycloakReactiveOAuth2ClientConfigurer` to be wrongly registered even if there are no Keycloak client configurations, if there are other OAuth2 client registrations