### PR TITLE
Move KeycloakOidcUserGrantedAuthoritiesConverter out of servlet package

### DIFF
--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/KeycloakClientConfiguration.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/KeycloakClientConfiguration.kt
@@ -1,10 +1,13 @@
 package com.github.daniel.shuy.oauth2.keycloak.client
 
+import com.github.daniel.shuy.oauth2.keycloak.KeycloakJwtClaimsAuthoritiesConverter
 import com.github.daniel.shuy.oauth2.keycloak.KeycloakProperties
 import com.github.daniel.shuy.oauth2.keycloak.client.reactive.KeycloakReactiveClientConfiguration
 import com.github.daniel.shuy.oauth2.keycloak.client.servlet.KeycloakServletClientConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.security.oauth2.client.registration.ClientRegistration
@@ -24,4 +27,12 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
     KeycloakServletClientConfiguration::class,
     KeycloakReactiveClientConfiguration::class,
 )
-internal class KeycloakClientConfiguration
+internal class KeycloakClientConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    fun keycloakOidcUserGrantedAuthoritiesConverter(
+        keycloakJwtClaimsAuthoritiesConverter: KeycloakJwtClaimsAuthoritiesConverter,
+    ): KeycloakOidcUserGrantedAuthoritiesConverter = DefaultKeycloakOidcUserGrantedAuthoritiesConverter(
+        keycloakJwtClaimsAuthoritiesConverter,
+    )
+}

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/KeycloakOidcUserGrantedAuthoritiesConverter.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/KeycloakOidcUserGrantedAuthoritiesConverter.kt
@@ -1,4 +1,4 @@
-package com.github.daniel.shuy.oauth2.keycloak.client.servlet
+package com.github.daniel.shuy.oauth2.keycloak.client
 
 import com.github.daniel.shuy.oauth2.keycloak.KeycloakJwtClaimsAuthoritiesConverter
 import com.nimbusds.jwt.JWTParser
@@ -7,8 +7,6 @@ import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority
 import org.springframework.security.oauth2.jwt.JwtDecoder
-
-// TODO: move to client folder
 
 /**
  * Converts [OidcUserRequest] and [OidcUser] for Keycloak to Spring Security granted authorities.

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/reactive/KeycloakOidcReactiveOAuth2UserService.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/reactive/KeycloakOidcReactiveOAuth2UserService.kt
@@ -1,6 +1,6 @@
 package com.github.daniel.shuy.oauth2.keycloak.client.reactive
 
-import com.github.daniel.shuy.oauth2.keycloak.client.servlet.KeycloakOidcUserGrantedAuthoritiesConverter
+import com.github.daniel.shuy.oauth2.keycloak.client.KeycloakOidcUserGrantedAuthoritiesConverter
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcReactiveOAuth2UserService
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/reactive/KeycloakReactiveClientConfiguration.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/reactive/KeycloakReactiveClientConfiguration.kt
@@ -1,7 +1,7 @@
 package com.github.daniel.shuy.oauth2.keycloak.client.reactive
 
 import com.github.daniel.shuy.oauth2.keycloak.client.KeycloakClientConfiguredCondition
-import com.github.daniel.shuy.oauth2.keycloak.client.servlet.KeycloakOidcUserGrantedAuthoritiesConverter
+import com.github.daniel.shuy.oauth2.keycloak.client.KeycloakOidcUserGrantedAuthoritiesConverter
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/servlet/KeycloakOidcUserService.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/servlet/KeycloakOidcUserService.kt
@@ -1,5 +1,6 @@
 package com.github.daniel.shuy.oauth2.keycloak.client.servlet
 
+import com.github.daniel.shuy.oauth2.keycloak.client.KeycloakOidcUserGrantedAuthoritiesConverter
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/servlet/KeycloakServletClientConfiguration.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/servlet/KeycloakServletClientConfiguration.kt
@@ -1,7 +1,7 @@
 package com.github.daniel.shuy.oauth2.keycloak.client.servlet
 
-import com.github.daniel.shuy.oauth2.keycloak.KeycloakJwtClaimsAuthoritiesConverter
 import com.github.daniel.shuy.oauth2.keycloak.client.KeycloakClientConfiguredCondition
+import com.github.daniel.shuy.oauth2.keycloak.client.KeycloakOidcUserGrantedAuthoritiesConverter
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -18,14 +18,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 @ConditionalOnClass(EnableWebSecurity::class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 internal class KeycloakServletClientConfiguration {
-    @Bean
-    @ConditionalOnMissingBean
-    fun keycloakOidcUserGrantedAuthoritiesConverter(
-        keycloakJwtClaimsAuthoritiesConverter: KeycloakJwtClaimsAuthoritiesConverter,
-    ): KeycloakOidcUserGrantedAuthoritiesConverter = DefaultKeycloakOidcUserGrantedAuthoritiesConverter(
-        keycloakJwtClaimsAuthoritiesConverter,
-    )
-
     @Bean
     fun keycloakOidcUserService(
         keycloakOidcUserGrantedAuthoritiesConverter: KeycloakOidcUserGrantedAuthoritiesConverter,


### PR DESCRIPTION
`KeycloakOidcUserGrantedAuthoritiesConverter` is used by both servlet/reactive client configurations