### PR TITLE
Support trailing slash in keycloak.auth-server-url

### DIFF
--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/KeycloakOAuth2EnvironmentPostProcessor.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/KeycloakOAuth2EnvironmentPostProcessor.kt
@@ -48,7 +48,7 @@ public object KeycloakOAuth2EnvironmentPostProcessor : EnvironmentPostProcessor 
 
         val propertySources = environment.propertySources
 
-        val authServerUrl = environment.getRequiredProperty(PROPERTY_AUTH_SERVER_URL)
+        val authServerUrl = environment.getRequiredProperty(PROPERTY_AUTH_SERVER_URL).appendIfMissing('/')
         val realm = environment.getRequiredProperty(PROPERTY_REALM)
         val clientId = environment.getRequiredProperty(PROPERTY_CLIENT_ID)
         val clientSecret = environment.getProperty(PROPERTY_CLIENT_SECRET)
@@ -89,4 +89,6 @@ public object KeycloakOAuth2EnvironmentPostProcessor : EnvironmentPostProcessor 
             ),
         )
     }
+
+    private fun String.appendIfMissing(char: Char): String = if (this.endsWith(char)) this else "$this$char"
 }


### PR DESCRIPTION
This is required to support [testcontainers-keycloak](https://github.com/dasniko/testcontainers-keycloak) `2.x.x` (`3.x.x` requires Java `17+`), which returns `KeycloakContainer#getAuthServerUrl()` with a trailing slash. Instead of removing the trailing slash, we can make this library more flexible by supporting `keycloak.auth-server-url` both with/without trailing slash.