### PR TITLE
Improve KtLint configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,7 @@
 root = true
 
 [{*.kt,*.kts}]
+max_line_length = 140 # to align IntelliJ IDEA/Android Studio with KtLint configuration
+
 ktlint_standard_class-signature = disabled
 ktlint_standard_no-blank-line-in-list = disabled

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,5 +3,5 @@ root = true
 [{*.kt,*.kts}]
 max_line_length = 140 # to align IntelliJ IDEA/Android Studio with KtLint configuration
 
-ktlint_standard_class-signature = disabled
-ktlint_standard_no-blank-line-in-list = disabled
+ktlint_standard_class-signature = disabled # leads to too many unnecessary line breaks for constructors with multiple parameters
+ktlint_standard_no-blank-line-in-list = disabled # blank lines between list elements can be used for grouping

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,4 @@ max_line_length = 140 # to align IntelliJ IDEA/Android Studio with KtLint config
 
 ktlint_standard_class-signature = disabled # leads to too many unnecessary line breaks for constructors with multiple parameters
 ktlint_standard_no-blank-line-in-list = disabled # blank lines between list elements can be used for grouping
+ktlint_standard_no-blank-lines-in-chained-method-calls = disabled # blank lines between chained method calls can be used for grouping


### PR DESCRIPTION
- Explicitly add [max_line_length](https://pinterest.github.io/ktlint/latest/rules/standard/#max-line-length) to align IntelliJ IDEA/Android Studio with KtLint

- Add comments to explained disabled KtLint rules:
    - [standard:class-signature](https://pinterest.github.io/ktlint/latest/rules/standard/#class-signature): leads to too many unnecessary line breaks for constructors with multiple parameters
    - [standard:no-blank-line-in-list](https://pinterest.github.io/ktlint/latest/rules/standard/#no-blank-lines-in-list): blank lines between list elements can be used for grouping

- Disable [standard:no-blank-lines-in-chained-method-calls](https://pinterest.github.io/ktlint/latest/rules/standard/#no-blank-lines-in-chained-method-calls)
    - blank lines between chained method calls can be used for grouping, e.g.
    ```kotlin
    return http
        .authorizeRequests { authorize ->
            authorize
                .mvcMatchers("/foo")
                .hasRole("ROLE")

                .mvcMatchers("/bar")
                .hasAuthority("AUTHORITY")

                .anyRequest()
                .denyAll()
        }
        .build()
    ```