### PR TITLE
Configure JVM Target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -20,6 +19,7 @@ val isReleaseVersion = !version.toString().endsWith("-SNAPSHOT")
 kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.fromTarget(libs.versions.jvmTarget.get())
+        freeCompilerArgs = listOf("-Xjsr305=strict")
     }
     coreLibrariesVersion = libs.versions.kotlinLib.get()
     explicitApi()
@@ -128,12 +128,6 @@ dependencies {
     implementation(libs.kotlin.reflect)
 
     testImplementation(libs.spring.boot.starter.test)
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict")
-    }
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -17,16 +18,15 @@ description = "Spring Boot Starter for using Keycloak as the OAuth2 authorizatio
 val isReleaseVersion = !version.toString().endsWith("-SNAPSHOT")
 
 kotlin {
-    jvmToolchain(
-        libs.versions.java
-            .get()
-            .toInt(),
-    )
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget(libs.versions.jvmTarget.get())
+    }
     coreLibrariesVersion = libs.versions.kotlinLib.get()
     explicitApi()
 }
 
 java {
+    targetCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
     withJavadocJar()
     withSourcesJar()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 dokka = "1.9.20"
-java = "8"
+jvmTarget = "1.8"
 kotlinLib = "1.6.10"         # Kotlin version that is supported by spring-boot-dependencies
 kotlinPlugin = "2.0.0"
 ktlint = "1.3.0"


### PR DESCRIPTION
- Use [kotlin.compilerOptions.jvmTarget](https://kotlinlang.org/docs/gradle-compiler-options.html#attributes-common-to-jvm-js-and-js-dce) and [java.targetCompatibility](https://docs.gradle.org/current/userguide/java_plugin.html#toolchain_and_compatibility) instead of [kotlin.jvmToolchain](https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support)
    - [kotlin.jvmToolchain](https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support) restricts the version of the JDK used, while [kotlin.compilerOptions.jvmTarget](https://kotlinlang.org/docs/gradle-compiler-options.html#attributes-common-to-jvm-js-and-js-dce) and [java.targetCompatibility](https://docs.gradle.org/current/userguide/java_plugin.html#toolchain_and_compatibility) allows a higher version of the JDK to be used, but compiles the code to target a different Java version

- Use `kotlin.compilerOptions.freeCompilerArgs` instead of `kotlinOptions.freeCompilerArgs`