### PR TITLE
Fix "member could be private" warnings

### DIFF
--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/KeycloakJwtClaimsAuthoritiesConverter.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/KeycloakJwtClaimsAuthoritiesConverter.kt
@@ -36,7 +36,7 @@ public open class DefaultKeycloakJwtClaimsAuthoritiesConverter(
             .concat(convertRealmRoles(jwtClaims), convertResourceRoles(jwtClaims))
             .toList()
 
-    protected fun convertRealmRoles(jwtClaims: JwtClaims): Stream<String> {
+    protected open fun convertRealmRoles(jwtClaims: JwtClaims): Stream<String> {
         val realmAccess =
             jwtClaims[CLAIM_REALM_ACCESS] as? Map<*, *>
                 ?: return Stream.empty()
@@ -46,7 +46,7 @@ public open class DefaultKeycloakJwtClaimsAuthoritiesConverter(
             .map { role -> "${GRANTED_AUTHORITY_PREFIX_ROLE}_$role" }
     }
 
-    protected fun convertResourceRoles(jwtClaims: JwtClaims): Stream<String> {
+    protected open fun convertResourceRoles(jwtClaims: JwtClaims): Stream<String> {
         val accessByResource =
             jwtClaims[CLAIM_RESOURCE_ACCESS] as? Map<*, *>
                 ?: return Stream.empty()

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/KeycloakJwtClaimsAuthoritiesConverter.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/KeycloakJwtClaimsAuthoritiesConverter.kt
@@ -19,7 +19,7 @@ public interface KeycloakJwtClaimsAuthoritiesConverter : Converter<JwtClaims, Co
  * - Keycloak Client Roles ([CLAIM_RESOURCE_ACCESS] roles) -> unchanged
  */
 public open class DefaultKeycloakJwtClaimsAuthoritiesConverter(
-    protected val keycloakResource: String,
+    private val keycloakResource: String,
 ) : KeycloakJwtClaimsAuthoritiesConverter {
     public companion object {
         protected const val CLAIM_REALM_ACCESS: String = "realm_access"

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/KeycloakOidcUserGrantedAuthoritiesConverter.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/KeycloakOidcUserGrantedAuthoritiesConverter.kt
@@ -23,7 +23,7 @@ public interface KeycloakOidcUserGrantedAuthoritiesConverter {
  * [JwtDecoder] and [KeycloakJwtClaimsAuthoritiesConverter].
  */
 public open class DefaultKeycloakOidcUserGrantedAuthoritiesConverter(
-    protected val keycloakJwtClaimsAuthoritiesConverter: KeycloakJwtClaimsAuthoritiesConverter,
+    private val keycloakJwtClaimsAuthoritiesConverter: KeycloakJwtClaimsAuthoritiesConverter,
 ) : KeycloakOidcUserGrantedAuthoritiesConverter {
     override fun toGrantedAuthorities(
         userRequest: OidcUserRequest,

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/reactive/KeycloakReactiveOAuth2ClientConfigurer.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/reactive/KeycloakReactiveOAuth2ClientConfigurer.kt
@@ -16,7 +16,7 @@ public interface KeycloakReactiveOAuth2ClientConfigurer {
  * Configure filter as an OAuth2 Client for Keycloak using `spring-security-oauth2-client`.
  */
 public open class DefaultKeycloakReactiveOAuth2ClientConfigurer(
-    protected val clientRegistrationRepository: ReactiveClientRegistrationRepository,
+    private val clientRegistrationRepository: ReactiveClientRegistrationRepository,
 ) : KeycloakReactiveOAuth2ClientConfigurer {
     override fun configureOAuth2Client(http: ServerHttpSecurity) {
         http

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/servlet/KeycloakOAuth2ClientConfigurer.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/client/servlet/KeycloakOAuth2ClientConfigurer.kt
@@ -18,8 +18,8 @@ public interface KeycloakOAuth2ClientConfigurer {
  * Configure filter as an OAuth2 Client for Keycloak using `spring-security-oauth2-client`.
  */
 public open class DefaultKeycloakOAuth2ClientConfigurer(
-    protected val clientRegistrationRepository: ClientRegistrationRepository,
-    protected val keycloakOidcUserService: KeycloakOidcUserService,
+    private val clientRegistrationRepository: ClientRegistrationRepository,
+    private val keycloakOidcUserService: KeycloakOidcUserService,
 ) : KeycloakOAuth2ClientConfigurer {
     override fun configureOAuth2Client(http: HttpSecurity) {
         http

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/server/resource/KeycloakJwtGrantedAuthoritiesConverter.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/server/resource/KeycloakJwtGrantedAuthoritiesConverter.kt
@@ -16,7 +16,7 @@ public interface KeycloakJwtGrantedAuthoritiesConverter : Converter<Jwt, Collect
  * [KeycloakJwtClaimsAuthoritiesConverter].
  */
 public open class DefaultKeycloakJwtGrantedAuthoritiesConverter(
-    protected val keycloakJwtClaimsAuthoritiesConverter: KeycloakJwtClaimsAuthoritiesConverter,
+    private val keycloakJwtClaimsAuthoritiesConverter: KeycloakJwtClaimsAuthoritiesConverter,
 ) : KeycloakJwtGrantedAuthoritiesConverter {
     override fun convert(jwt: Jwt): List<SimpleGrantedAuthority>? =
         keycloakJwtClaimsAuthoritiesConverter

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/server/resource/reactive/KeycloakReactiveOAuth2ResourceServerConfigurer.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/server/resource/reactive/KeycloakReactiveOAuth2ResourceServerConfigurer.kt
@@ -13,7 +13,7 @@ public interface KeycloakReactiveOAuth2ResourceServerConfigurer {
  * Configure filter as an OAuth2 resource server for Keycloak using `spring-security-oauth2-resource-server`.
  */
 public open class DefaultKeycloakReactiveOAuth2ResourceServerConfigurer(
-    protected val keycloakJwtAuthenticationConverter: KeycloakReactiveJwtAuthenticationConverter,
+    private val keycloakJwtAuthenticationConverter: KeycloakReactiveJwtAuthenticationConverter,
 ) : KeycloakReactiveOAuth2ResourceServerConfigurer {
     override fun configureOAuth2ResourceServer(http: ServerHttpSecurity) {
         http.oauth2ResourceServer(::oauth2ResourceServer)

--- a/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/server/resource/servlet/KeycloakOAuth2ResourceServerConfigurer.kt
+++ b/src/main/kotlin/com/github/daniel/shuy/oauth2/keycloak/server/resource/servlet/KeycloakOAuth2ResourceServerConfigurer.kt
@@ -15,7 +15,7 @@ public interface KeycloakOAuth2ResourceServerConfigurer {
  * Configure filter as an OAuth2 resource server for Keycloak using `spring-security-oauth2-resource-server`.
  */
 public open class DefaultKeycloakOAuth2ResourceServerConfigurer(
-    protected val keycloakJwtAuthenticationConverter: KeycloakJwtAuthenticationConverter,
+    private val keycloakJwtAuthenticationConverter: KeycloakJwtAuthenticationConverter,
 ) : KeycloakOAuth2ResourceServerConfigurer {
     override fun configureOAuth2ResourceServer(http: HttpSecurity) {
         http.oauth2ResourceServer(::oauth2ResourceServer)


### PR DESCRIPTION
- Explicitly declare overridable functions as `open`
- Change `protected` constructor properties to `private`
    - Since the properties are set by a constructor, subclasses can redeclare them if they need to access them