### PR TITLE
Fix usage of unsupported Java APIs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.spring)
@@ -17,8 +15,12 @@ description = "Spring Boot Starter for using Keycloak as the OAuth2 authorizatio
 val isReleaseVersion = !version.toString().endsWith("-SNAPSHOT")
 
 kotlin {
+    jvmToolchain(
+        libs.versions.java
+            .get()
+            .toInt(),
+    )
     compilerOptions {
-        jvmTarget = JvmTarget.fromTarget(libs.versions.jvmTarget.get())
         freeCompilerArgs = listOf("-Xjsr305=strict")
     }
     coreLibrariesVersion = libs.versions.kotlinLib.get()
@@ -26,7 +28,6 @@ kotlin {
 }
 
 java {
-    targetCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
     withJavadocJar()
     withSourcesJar()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 dokka = "1.9.20"
-jvmTarget = "1.8"
+java = "8"
 kotlinLib = "1.6.10"         # Kotlin version that is supported by spring-boot-dependencies
 kotlinPlugin = "2.0.0"
 ktlint = "1.3.0"


### PR DESCRIPTION
Revert 026c7f159879ca1b2b7542c877f26f0f103c9821
- `kotlin.jvmToolchain` is required to prevent accidental usage of unsupported Java APIs, e.g. [Stream#toList()](https://docs.oracle.com/en//java/javase/16/docs/api/java.base/java/util/stream/Stream.html#toList()), which was added in Java `16`
