### PR TITLE
Gradle Build Reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,3 +66,10 @@ jobs:
         with:
           name: test-results
           path: "**/build/test-results/test/TEST-*.xml"
+
+      - name: Upload build reports
+        uses: actions/upload-artifact@v4
+        if: success() || failure()  # run this step even if previous step failed
+        with:
+          name: build-reports
+          path: "**/build/reports/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:  # allow Action to be run manually
 
+permissions:
+  pull-requests: write
+
 jobs:
   validate-renovate-config:
     runs-on: ubuntu-latest
@@ -49,6 +52,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
+          add-job-summary-as-pr-comment: on-failure
           build-scan-publish: true
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
           build-scan-terms-of-use-agree: "yes"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,3 +59,10 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: success() || failure()  # run this step even if previous step failed
+        with:
+          name: test-results
+          path: "**/build/test-results/test/TEST-*.xml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,10 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
 
       - name: Publish package with Gradle
         run: >-

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,23 @@
+name: 'Test Report'
+
+on:
+  workflow_run:
+    workflows: ['Build']
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v1
+        with:
+          artifact: test-results
+          name: JUnit Tests
+          path: "**/*.xml"
+          reporter: java-junit


### PR DESCRIPTION
- [Configure Build Scan for Gradle](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#develocity-build-scan-integration)
- [Add Job Summary as PR comment](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#adding-job-summary-as-a-pull-request-comment)
- Display test report using [Test Reporter GitHub Action](https://github.com/marketplace/actions/test-reporter)
- [Save build outputs](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#saving-arbitrary-build-outputs)