### PR TITLE
Release configuration

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -47,6 +47,12 @@ tasks.named("afterReleaseBuild") {
     dependsOn("publish")
 }
 
+release {
+    git {
+        requireBranch = "" // allow releasing from any branch
+    }
+}
+
 publishing {
     publications {
         create<MavenPublication>("lib") {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -50,6 +50,7 @@ tasks.named("afterReleaseBuild") {
 release {
     git {
         requireBranch = "" // allow releasing from any branch
+        signTag = true
     }
 }
 


### PR DESCRIPTION
- Allow releasing from any branch (by default, the [gradle-release-plugin](https://github.com/researchgate/gradle-release) only allows releasing from `main` branch)
- Sign release git tags