### PR TITLE
Add write packages permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 env:
   BRANCH: ${{ github.ref_name }}


### PR DESCRIPTION
Required to publish to GitHub Packages (see https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-java-packages-with-gradle#publishing-packages-to-github-packages)