### PR TITLE
Move project version to gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version=0.0.1-SNAPSHOT

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
 }
 
 group = "com.github.daniel-shuy"
-version = "0.0.1-SNAPSHOT"
 description = "Spring Boot Starter for using Keycloak as the OAuth2 authorization server"
 
 val isReleaseVersion = !version.toString().endsWith("-SNAPSHOT")


### PR DESCRIPTION
[gradle-release-plugin](https://github.com/researchgate/gradle-release) requires project version to be defined in `gradle.properties` file