### PR TITLE
Limit permissions to GitHub Action jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,6 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:  # allow Action to be run manually
 
-permissions:
-  pull-requests: write
-
 jobs:
   validate-renovate-config:
     runs-on: ubuntu-latest
@@ -39,6 +36,8 @@ jobs:
         run: npm run renovate-config-validator
   build:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout with GIT
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,15 @@ on:
       - release/*
   workflow_dispatch:  # allow Action to be run manually
 
-permissions:
-  contents: write
-  packages: write
-
 env:
   BRANCH: ${{ github.ref_name }}
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:  # required to publish to GitHub Packages
-      contents: read
-      packages: write
+    permissions:
+      contents: write # required to merge branch
+      packages: write # required to publish to GitHub Packages
     steps:
       - name: Validate branch
         if: startsWith(env.BRANCH, 'hotfix/') != true && startsWith(env.BRANCH, 'release/') != true


### PR DESCRIPTION
https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token

> You can use the permissions key in your workflow file to modify permissions for the GITHUB_TOKEN for an entire workflow or for individual jobs. This allows you to configure the minimum required permissions for a workflow or job. When the permissions key is used, all unspecified permissions are set to no access, with the exception of the metadata scope, which always gets read access.

> The two workflow examples earlier in this article show the permissions key being used at the job level, as it is best practice to limit the permissions' scope.