### PR TITLE
Set up GIT user in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
           build-scan-terms-of-use-agree: "yes"
 
+      - name: Set up GIT user
+        uses: fregante/setup-git-user@v2
+
       - name: Publish package with Gradle
         run: >-
           ./gradlew release


### PR DESCRIPTION
Required for [gradle-release-plugin](https://github.com/researchgate/gradle-release) to commit to GIT