### PR TITLE
Disable signed push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           git_tag_gpgsign: true
-          git_push_gpgsign: true
 
       - name: Publish package with Gradle
         run: >-


### PR DESCRIPTION
GitHub doesn't support signed push (see https://github.com/orgs/community/discussions/23515)