### PR TITLE
Suppress Maven publication POM metadata warnings for test fixtures

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -55,7 +55,7 @@ release {
 
 publishing {
     publications {
-        create<MavenPublication>("lib") {
+        register<MavenPublication>("lib") {
             artifactId = "oauth2-keycloak-spring-boot-starter"
             description = project.description
 
@@ -85,6 +85,9 @@ publishing {
                     tag.set("HEAD")
                 }
             }
+
+            suppressPomMetadataWarningsFor("testFixturesApiElements")
+            suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
         }
     }
 


### PR DESCRIPTION
Prevents the build warnings:

> Maven publication 'lib' pom metadata warnings (silence with 'suppressPomMetadataWarningsFor(variant)'):
>   - Variant testFixturesApiElements:
>       - Declares capability com.github.daniel-shuy:lib-test-fixtures:1.0.0 which cannot be mapped to Maven
>   - Variant testFixturesRuntimeElements:
>       - Declares capability com.github.daniel-shuy:lib-test-fixtures:1.0.0 which cannot be mapped to Maven
> These issues indicate information that is lost in the published 'pom' metadata file, which may be an issue if the published library is consumed by an old Gradle version or Apache Maven.
> The 'module' metadata file, which is used by Gradle 6+ is not affected.

This is due to Gradle not being able to map the test fixtures to Maven (https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html#sub:mapping-with-other-formats), because there is no equivalent concept in Maven.