### PR TITLE
Update .gitignore for Kotlin 2.x.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,8 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/gradle
 
+# Kotlin
+.kotlin/
+
 # Node
 node_modules/


### PR DESCRIPTION
Since Kotlin `2.0.0`, the Kotlin Gradle plugin stores Kotlin data in `.kotlin` instead of `.gradle/kotlin` (see https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects)