### PR TITLE
Use HttpSecurity#authorizeHttpRequests instead of HttpSecurity#authorizeRequests

### DIFF
--- a/test/client/servlet/src/test/kotlin/test/ServletClientPrincipalAttributeSpec.kt
+++ b/test/client/servlet/src/test/kotlin/test/ServletClientPrincipalAttributeSpec.kt
@@ -38,7 +38,7 @@ class ServletClientPrincipalAttributeSpec(
             @Bean
             fun keycloakHttpSecurityCustomizer() =
                 KeycloakHttpSecurityCustomizer { http ->
-                    http.authorizeRequests { authorize ->
+                    http.authorizeHttpRequests { authorize ->
                         authorize
                             .anyRequest()
                             .authenticated()

--- a/test/resource-server/servlet/src/test/kotlin/test/ServletResourceServerPrincipalAttributeSpec.kt
+++ b/test/resource-server/servlet/src/test/kotlin/test/ServletResourceServerPrincipalAttributeSpec.kt
@@ -47,7 +47,7 @@ class ServletResourceServerPrincipalAttributeSpec(
             @Bean
             fun keycloakHttpSecurityCustomizer() =
                 KeycloakHttpSecurityCustomizer { http ->
-                    http.authorizeRequests { authorize ->
+                    http.authorizeHttpRequests { authorize ->
                         authorize
                             .anyRequest()
                             .authenticated()


### PR DESCRIPTION
`HttpSecurity#authorizeRequests` is deprecated